### PR TITLE
Tweak meta.yaml to fix build on MacOS X

### DIFF
--- a/recipe/libcypher-parser/meta.yaml
+++ b/recipe/libcypher-parser/meta.yaml
@@ -11,11 +11,12 @@ source:
   url: https://github.com/cleishm/libcypher-parser/releases/download/v0.6.2/libcypher-parser-0.6.2.tar.gz
 
 build:
-  number: 1
+  number: 3
 
 requirements:
   build:
     - make
+    - wget
     #   cloning from git URL requires extra build deps:
     #- git
     #- autoconf
@@ -26,8 +27,6 @@ test:
   commands:
     - test -f $PREFIX/include/cypher-parser.h
     - test -f $PREFIX/bin/cypher-lint
-    - test -f $PREFIX/lib/libcypher-parser.a
-    - test -f $PREFIX/lib/libcypher-parser.so
 
 about:
   home: https://github.com/cleishm/libcypher-parser.git


### PR DESCRIPTION
Adds wget to build requirements and removes tests that only apply to linux.